### PR TITLE
Add option to just get version and return a clean exit code when help is invoked.

### DIFF
--- a/gffcompare.cpp
+++ b/gffcompare.cpp
@@ -21,6 +21,7 @@ gffcompare [-r <reference_mrna.gtf> [-R]] [-G] [-T] [-V] [-s <seq_path>]\n\
  across samples).\n\
 \n\
  Options:\n\
+ -v display gffcompare version\n\
  -i provide a text file with a list of (query) GTF files to process instead\n\
     of expecting them as command line arguments (useful when a large number\n\
     of GTF files should be processed)\n\
@@ -166,6 +167,9 @@ int cmpGTrackByName(const pointer p1, const pointer p2) {
  return strcmp(((GSeqTrack*)p1)->gseq_name, ((GSeqTrack*)p2)->gseq_name);
 }
 
+void show_version() {
+  GMessage("gffcompare v%s\n", VERSION);
+}
 
 void show_usage() {
   GMessage("gffcompare v%s\n", VERSION);
@@ -180,7 +184,7 @@ int main(int argc, char * const argv[]) {
       HeapProfilerStart("./gffcompare_dbg.hprof");
 #endif
 
-  GArgs args(argc, argv, "XDTMNVFGSCKQRLhp:e:d:s:i:n:r:o:");
+  GArgs args(argc, argv, "vXDTMNVFGSCKQRLhp:e:d:s:i:n:r:o:");
   int e;
   if ((e=args.isError())>0) {
     show_usage();
@@ -191,6 +195,10 @@ int main(int argc, char * const argv[]) {
     show_usage();
     exit(0);
     }
+  if (args.getOpt('v')!=NULL){
+    show_version();
+    exit(0);
+  }
   showContained=(args.getOpt('C')!=NULL);
   debug=(args.getOpt('D')!=NULL);
   tmapFiles=(args.getOpt('T')==NULL);

--- a/gffcompare.cpp
+++ b/gffcompare.cpp
@@ -189,7 +189,7 @@ int main(int argc, char * const argv[]) {
     }
   if (args.getOpt('h')!=NULL){
     show_usage();
-    exit(1);
+    exit(0);
     }
   showContained=(args.getOpt('C')!=NULL);
   debug=(args.getOpt('D')!=NULL);


### PR DESCRIPTION
This will help testing whether or not the build was successful with `bioconda` or `homebrew` and the like.