### PR TITLE
--cds-match to force matching CDS in addition to exon. 

### DIFF
--- a/gtf_tracking.cpp
+++ b/gtf_tracking.cpp
@@ -9,6 +9,7 @@ bool reduceRefs=false; //-R
 
 bool qDupStrict=false;
 bool stricterMatching=false;
+bool cdsMatching=false;
 bool cSETMerge=false;
 int terminalMatchRange=0;
 bool noMergeCloseExons=false;
@@ -559,11 +560,11 @@ void gatherRefLocOvls(GffObj& m, GLocus& rloc) {
 	}
 	for (int i=0;i<rloc.mrnas.Count();i++) {
 		GffObj* r=rloc.mrnas[i];
-		TOvlData ovld=getOvlData(m,*r, stricterMatching);
+		TOvlData ovld=getOvlData(m,*r, stricterMatching, 1, cdsMatching);
 		if (ovld.ovlcode!=0) { //has some sort of overlap with r
 			((CTData*)m.uptr)->addOvl(ovld,r);
 			//if (classcode_rank(olen>ovlen) { ovlen=olen; rovl=r; }
-			if (ovld.ovlcode=='c' || ovld.ovlcode=='=' || ovld.ovlcode=='~') //keep match/containment for each reference transcript
+			if (ovld.ovlcode=='c' || ovld.ovlcode=='=' || ovld.ovlcode=='~' || ovld.ovlcode==':' || ovld.ovlcode=='_') //keep match/containment for each reference transcript
 				((CTData*)r->uptr)->addOvl(ovld, &m);
 		}
 	}//for each ref in rloc

--- a/gtf_tracking.h
+++ b/gtf_tracking.h
@@ -18,6 +18,7 @@ extern bool gtf_tracking_verbose;
 extern bool gtf_tracking_largeScale;
 extern bool qDupStrict;
 extern bool stricterMatching;
+extern bool cdsMatching;
 extern int terminalMatchRange;
 extern bool noMergeCloseExons;
 extern bool cSETMerge;

--- a/trmap.cpp
+++ b/trmap.cpp
@@ -17,6 +17,7 @@
 
 bool simpleOvl=false;
 bool stricterMatching=false;
+bool cdsMatching=false;
 bool showCDS=false;
 bool outRefOvlTab=false;
 bool novelJTab=false;
@@ -509,7 +510,7 @@ int main(int argc, char* argv[]) {
 				GffObj* r=(GffObj*)enu->Get(i);
 				if (selfMap && strcmp(r->getID(), t->getID())==0)
 					continue; // skip self matches
-				TOvlData od=getOvlData(*t, *r, stricterMatching);
+				TOvlData od=getOvlData(*t, *r, stricterMatching, 1, cdsMatching);
 				// opposite strand non-overlaps should be ignored ?
 				bool Xstrand=(t->strand!=r->strand && t->strand!='.' && r->strand!='.');
 				if (Xstrand && classcode_rank(od.ovlcode)<CLASSCODE_OVL_RANK) {


### PR DESCRIPTION
This fix introduces a new flag '--cds-match' which performs validation of CDS chains in addition to the exon chains. Current implementation only addresses CDS matching for '=' and '~' cases. This feature is intended for use with polycistronic transcripts and for comparing annotations with similar exon structures but differing ORFs.

The fix introduces two new classification codes ':' and '_' which replace '=' and '~' when no matching CDS is found. An appropriate fix is also issued to the gclib to support the two new codes.