### PR TITLE
Include gclib license file in release artifact

### DIFF
--- a/prep_source.sh
+++ b/prep_source.sh
@@ -15,6 +15,7 @@ cp LICENSE README.md gffcompare.cpp gtf_tracking.{h,cpp} \
 sed 's|\.\./gclib|./gclib|' Makefile > $pack/Makefile
 cp ../gclib/{GVec,GList,GIntervalTree,GHashMap,khashl}.hh ../gclib/xxhash.h ../gclib/wyhash.h ../gclib/GBitVec.h $libdir
 cp ../gclib/{GArgs,GBase,gdna,GStr,gff,codons,GFaSeqGet,GFastaIndex}.{h,cpp} $libdir
+cp ../gclib/LICENSE.txt $libdir
 tar cvfz $pack.tar.gz $pack
 ls -l $pack.tar.gz
 


### PR DESCRIPTION
Hi, thanks for gffcompare! This adds the gclib license to the release tarball.