### PR TITLE
Add noexcept to move constructor in GList

### DIFF
--- a/gclib/GList.hh
+++ b/gclib/GList.hh
@@ -98,7 +98,7 @@ template <class OBJ> class GList:public GPVec<OBJ> {
     GList(bool sorted, bool free_elements=true, bool beUnique=false);
     GList(int init_capacity, bool sorted, bool free_elements=true, bool beUnique=false);
     GList(const GList<OBJ>& list); //copy constructor
-    GList(GList<OBJ>&& list); //move constructor
+    GList(GList<OBJ>&& list) noexcept; //move constructor
     GList(GList<OBJ>* list); //kind of a copy constructor
     GList<OBJ>& operator=(GList<OBJ>& list); //copy operator
     GList<OBJ>& operator=(GList<OBJ>&& list); //move operator


### PR DESCRIPTION
gcc15 error

```
g++ -O3 -DNDEBUG -Wall -Wextra -std=c++11 -I./gclib -D_REENTRANT -fno-exceptions -fno-rtti -Wno-class-memaccess -march=x86-64 -mtune=generic -O2 -pipe -fno-plt -fexceptions         -Wp,-D_FORTIFY_SOURCE=3 -Wformat -Werror=format-security         -fstack-clash-protection -fcf-protection         -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -Wp,-D_GLIBCXX_ASSERTIONS -g -ffile-prefix-map=/home/guoyi/Downloads/Packages/BioArchLinux/gffcompare/src=/usr/src/debug/gffcompare -flto=auto -c gclib/GFastaIndex.cpp -o gclib/GFastaIndex.o
In file included from gclib/GFastaIndex.h:12,
                 from gclib/GFastaIndex.cpp:8:
gclib/GList.hh:375:22: error: declaration of ‘GList<OBJ>::GList(GList<OBJ>&&) noexcept’ has a different exception specifier [-Wtemplate-body]
  375 | template <class OBJ> GList<OBJ>::GList(GList<OBJ>&& other) noexcept:
      |                      ^~~~~~~~~~
gclib/GList.hh:101:5: note: from previous declaration ‘GList<OBJ>::GList(GList<OBJ>&&)’
  101 |     GList(GList<OBJ>&& list); //move constructor
```